### PR TITLE
add first name and last name fields when registering

### DIFF
--- a/frontend/src/pages/auth/components/RegisterForm.tsx
+++ b/frontend/src/pages/auth/components/RegisterForm.tsx
@@ -1,14 +1,16 @@
-import { FormErrorMessage, FormLabel, FormControl, Input, Button } from "@chakra-ui/react";
+import { Button, FormErrorMessage, FormLabel, FormControl, Input, Stack } from "@chakra-ui/react";
 
 import { useForm } from "react-hook-form";
 
 type RegisterFormProps = {
-  onRegister: (email: string, password: string) => unknown;
+  onRegister: (firstName: string, lastName: string, email: string, password: string) => unknown;
 };
 
 type RegisterFormValues = {
   confirmPassword: string;
   email: string;
+  firstName: string;
+  lastName: string;
   password: string;
 };
 
@@ -19,10 +21,44 @@ export const RegisterForm = ({ onRegister }: RegisterFormProps) => {
     register,
   } = useForm<RegisterFormValues>();
 
-  const submitHandler = ({ email, password }: RegisterFormValues) => onRegister(email, password);
+  const submitHandler = ({ email, firstName, lastName, password }: RegisterFormValues) => {
+    return onRegister(firstName, lastName, email, password);
+  };
 
   return (
     <form onSubmit={handleSubmit(submitHandler)}>
+      <Stack direction="row">
+        <FormControl isInvalid={!!errors.firstName}>
+          <FormLabel htmlFor="firstName">First Name</FormLabel>
+
+          <Input
+            id="firstName"
+            type="text"
+            placeholder="First Name"
+            {...register("firstName", {
+              required: "First name is required",
+            })}
+          />
+
+          {errors.firstName && <FormErrorMessage>{errors.firstName.message}</FormErrorMessage>}
+        </FormControl>
+
+        <FormControl isInvalid={!!errors.lastName}>
+          <FormLabel htmlFor="lastName">Last Name</FormLabel>
+
+          <Input
+            id="lastName"
+            type="text"
+            placeholder="Last Name"
+            {...register("lastName", {
+              required: "Last name is required",
+            })}
+          />
+
+          {errors.lastName && <FormErrorMessage>{errors.lastName.message}</FormErrorMessage>}
+        </FormControl>
+      </Stack>
+
       <FormControl isInvalid={!!errors.email}>
         <FormLabel htmlFor="email">Email</FormLabel>
 

--- a/frontend/src/pages/auth/routes/Register.tsx
+++ b/frontend/src/pages/auth/routes/Register.tsx
@@ -10,8 +10,10 @@ export const Register = () => {
 
   const [error, setError] = useState<string | null>(null);
 
-  const handleRegister = (email: string, password: string) => {
-    register(email, password)
+  const handleRegister = (firstName: string, lastName: string, email: string, password: string) => {
+    const displayName = `${firstName.trim()} ${lastName.trim()}`;
+
+    register(displayName, email, password)
       .then(() => redirect("/"))
       .catch((error) => {
         if (error instanceof AuthError) {

--- a/frontend/src/providers/auth/AuthProvider.tsx
+++ b/frontend/src/providers/auth/AuthProvider.tsx
@@ -8,6 +8,7 @@ import {
   sendPasswordResetEmail,
   signInWithEmailAndPassword,
   updatePassword,
+  updateProfile,
   verifyPasswordResetCode,
 } from "firebase/auth";
 
@@ -89,9 +90,13 @@ export const AuthProvider = ({ children, loadingFallback }: AuthProviderProps) =
     await auth.signOut();
   };
 
-  const register = async (email: string, password: string) => {
+  const register = async (displayName: string, email: string, password: string) => {
     try {
-      await createUserWithEmailAndPassword(auth, email, password);
+      const { user } = await createUserWithEmailAndPassword(auth, email, password);
+
+      await updateProfile(user, {
+        displayName,
+      });
     } catch (error: any) {
       switch (error.code) {
         case "auth/email-already-in-use":

--- a/frontend/src/providers/auth/auth-context.ts
+++ b/frontend/src/providers/auth/auth-context.ts
@@ -65,12 +65,13 @@ export type AuthContext = {
 
   /**
    * Register a new user with the given email and password.
+   * @param displayName The display name of the uesr
    * @param email The email address to register with
    * @param password The password to register with
    * @returns A promise that resolves if the registration was successful, or rejects
    * with an error message if the registration failed.
    */
-  register: (email: string, password: string) => Promise<void>;
+  register: (displayName: string, email: string, password: string) => Promise<void>;
 
   /**
    * Reset the user's password with the given code and new password.


### PR DESCRIPTION
Add inputs for first and last name when registering for a new account. This will be set as the user's display name when accessing the `displayName` field of the current user when using the `useCurrentUser()` hook.