### PR TITLE
Add settings page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@chakra-ui/react": "^2.8.1",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
+        "@uidotdev/usehooks": "^2.4.1",
         "chart.js": "^4.4.0",
         "firebase": "^10.4.0",
         "framer-motion": "^10.16.4",
@@ -2946,6 +2947,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@uidotdev/usehooks": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@uidotdev/usehooks/-/usehooks-2.4.1.tgz",
+      "integrity": "sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react-swc": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,10 +18,10 @@
     "framer-motion": "^10.16.4",
     "konva": "^9.2.1",
     "react": "^18.2.0",
-    "react-icons": "^4.11.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.46.1",
+    "react-icons": "^4.11.0",
     "react-konva": "^18.2.10",
     "react-router-dom": "^6.16.0"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@chakra-ui/react": "^2.8.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@uidotdev/usehooks": "^2.4.1",
     "chart.js": "^4.4.0",
     "firebase": "^10.4.0",
     "framer-motion": "^10.16.4",

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,104 +1,89 @@
 import {
-    Box,
-    Flex,
-    Avatar,
-    HStack,
-    IconButton,
-    Button,
-    Menu,
-    MenuButton,
-    MenuList,
-    MenuItem,
-    MenuDivider,
-    useDisclosure,
-    Stack,
+  Box,
+  Flex,
+  Avatar,
+  HStack,
+  IconButton,
+  Button,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  MenuDivider,
+  useDisclosure,
+  Stack,
 } from "@chakra-ui/react";
 import { redirect } from "react-router-dom";
-import { useAuth, useCurrentUser } from "../providers";
 import { MdClose } from "react-icons/md";
 import { GiHamburgerMenu } from "react-icons/gi";
 import { TbPencilSearch } from "react-icons/tb";
 
+import { useAuth } from "../providers";
+
 const Navbar = () => {
-    const { isOpen, onOpen, onClose } = useDisclosure()
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
-    const { currentUser, logout } = useAuth();
+  const { logout } = useAuth();
 
-    const handleLogout = () => {
-        if (!currentUser) {
-            redirect("/");
-        } else {
-            logout()
-                .then(() => redirect("/"))
-                .catch((error) => {
-                    console.log("logout error: ", error)
-                })
-        }
-    }
+  const handleLogout = () => {
+    logout().then(() => redirect("/"));
+  };
 
-    return (
-        <Box w="100vw" px="5" bg="white">
-            <Flex h="70px" alignItems={"center"} justifyContent={"space-between"}>
-                <IconButton
-                    size={"md"}
-                    as={isOpen ? MdClose : GiHamburgerMenu}
-                    boxSize={10}
-                    p="2"
-                    aria-label={"Open Menu"}
-                    display={{ md: "none" }}
-                    onClick={isOpen ? onClose : onOpen}
-                />
-                <HStack spacing={8} alignItems={"center"}>
-                    <Box>Logo</Box>
-                    <HStack as={"nav"} spacing={4} display={{ base: "none", md: "flex" }}>
-                        <Box key="link">Test</Box>
-                        <Box key="link">Test</Box>
-                        <Box key="link">Test</Box>
-                    </HStack>
-                </HStack>
-                <Flex alignItems={"center"}>
-                    <Button
-                        variant={"solid"}
-                        colorScheme={"teal"}
-                        size={"sm"}
-                        mr={4}
-                        leftIcon={<TbPencilSearch />}>
-                        Recommend Me a Question
-                    </Button>
-                    <Menu>
-                        <MenuButton
-                            as={Button}
-                            rounded={"full"}
-                            variant={"link"}
-                            cursor={"pointer"}
-                            minW={0}>
-                            <Avatar
-                                size={"md"}
-                                src={"https://bit.ly/dan-abramov"}
-                            />
-                        </MenuButton>
-                        <MenuList>
-                            <MenuItem>Link 1</MenuItem>
-                            <MenuItem>Link 2</MenuItem>
-                            <MenuDivider />
-                            <MenuItem onClick={handleLogout}>Logout</MenuItem>
-                        </MenuList>
-                    </Menu>
-                </Flex>
-            </Flex>
+  return (
+    <Box px="5" bg="white">
+      <Flex h="70px" alignItems={"center"} justifyContent={"space-between"}>
+        <IconButton
+          size={"md"}
+          as={isOpen ? MdClose : GiHamburgerMenu}
+          boxSize={10}
+          p="2"
+          aria-label={"Open Menu"}
+          display={{ md: "none" }}
+          onClick={isOpen ? onClose : onOpen}
+        />
+        <HStack spacing={8} alignItems={"center"}>
+          <Box>Logo</Box>
+          <HStack as={"nav"} spacing={4} display={{ base: "none", md: "flex" }}>
+            <Box key="link">Test</Box>
+            <Box key="link">Test</Box>
+            <Box key="link">Test</Box>
+          </HStack>
+        </HStack>
+        <Flex alignItems={"center"}>
+          <Button
+            variant={"solid"}
+            colorScheme={"teal"}
+            size={"sm"}
+            mr={4}
+            leftIcon={<TbPencilSearch />}
+          >
+            Recommend Me a Question
+          </Button>
+          <Menu>
+            <MenuButton as={Button} rounded={"full"} variant={"link"} cursor={"pointer"} minW={0}>
+              <Avatar size={"md"} src={"https://bit.ly/dan-abramov"} />
+            </MenuButton>
+            <MenuList>
+              <MenuItem>Link 1</MenuItem>
+              <MenuItem>Link 2</MenuItem>
+              <MenuDivider />
+              <MenuItem onClick={handleLogout}>Logout</MenuItem>
+            </MenuList>
+          </Menu>
+        </Flex>
+      </Flex>
 
-            {isOpen ? (
-                <Box pb={4} display={{ md: "none" }}>
-                    <Stack as={"nav"} spacing={4}>
-                        <Box key="link">Test</Box>
-                        <Box key="link">Test</Box>
-                        <Box key="link">Test</Box>
-                    </Stack>
-                </Box>
-            ) : null}
+      {isOpen ? (
+        <Box pb={4} display={{ md: "none" }}>
+          <Stack as={"nav"} spacing={4}>
+            <Box key="link">Test</Box>
+            <Box key="link">Test</Box>
+            <Box key="link">Test</Box>
+          </Stack>
         </Box>
-
-    )
-}
+      ) : null}
+    </Box>
+  );
+};
 
 export default Navbar;

--- a/frontend/src/pages/settings/components/ExamDate.tsx
+++ b/frontend/src/pages/settings/components/ExamDate.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+
+import { Box, Button, Heading, Stack, Text } from "@chakra-ui/react";
+import { FaPencil } from "react-icons/fa6";
+
+export const ExamDate = () => {
+  const [examDate, setExamDate] = useState<Date | null>(null);
+  const [examLocation, setExamLocation] = useState<string | null>(null);
+
+  useEffect(() => {
+    // TODO: Call API to get user's exam date and location
+    setExamDate(new Date());
+    setExamLocation("Hunter College");
+  }, []);
+
+  return (
+    <Stack gap={5}>
+      <Heading size="lg">
+        SAT Exam Date:
+        <Button variant="link" colorScheme="blue" size="lg" marginLeft="4">
+          <Box marginRight="1">
+            <FaPencil />
+          </Box>
+          Edit
+        </Button>
+      </Heading>
+
+      <Text fontSize="xl">
+        {examDate?.toLocaleDateString("en-US", {
+          weekday: "long",
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+        })}{" "}
+        {examDate?.toLocaleTimeString("en-US", {
+          hour: "numeric",
+          minute: "numeric",
+          timeZoneName: "long",
+        })}{" "}
+      </Text>
+
+      <Heading size="lg">SAT Exam Location:</Heading>
+
+      <Text fontSize="xl">{examLocation}</Text>
+    </Stack>
+  );
+};

--- a/frontend/src/pages/settings/components/ExamDate.tsx
+++ b/frontend/src/pages/settings/components/ExamDate.tsx
@@ -4,12 +4,25 @@ import { Box, Button, Heading, Stack, Text } from "@chakra-ui/react";
 import { FaPencil } from "react-icons/fa6";
 
 export const ExamDate = () => {
-  const [examDate, setExamDate] = useState<Date | null>(null);
+  const [examDate, setExamDate] = useState<string | null>(null);
   const [examLocation, setExamLocation] = useState<string | null>(null);
 
   useEffect(() => {
     // TODO: Call API to get user's exam date and location
-    setExamDate(new Date());
+    const date = new Date().toLocaleDateString("en-US", {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+
+    const time = new Date().toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "numeric",
+      timeZoneName: "long",
+    });
+
+    setExamDate(`${date} ${time}`);
     setExamLocation("Hunter College");
   }, []);
 
@@ -25,19 +38,7 @@ export const ExamDate = () => {
         </Button>
       </Heading>
 
-      <Text fontSize="xl">
-        {examDate?.toLocaleDateString("en-US", {
-          weekday: "long",
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        })}{" "}
-        {examDate?.toLocaleTimeString("en-US", {
-          hour: "numeric",
-          minute: "numeric",
-          timeZoneName: "long",
-        })}{" "}
-      </Text>
+      <Text fontSize="xl">{examDate || "No exam date set"}</Text>
 
       <Heading size="lg">SAT Exam Location:</Heading>
 

--- a/frontend/src/pages/settings/components/FocusTopics.tsx
+++ b/frontend/src/pages/settings/components/FocusTopics.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+
+import { Avatar, Box, Button, Stack, Tag, Text } from "@chakra-ui/react";
+import { FaPencil } from "react-icons/fa6";
+
+import { useCurrentUser } from "../../../providers";
+
+export const FocusTopics = () => {
+  const { displayName, email } = useCurrentUser();
+
+  const [topics, setTopics] = useState<string[]>([]);
+
+  useEffect(() => {
+    // TODO: Call API to get user's focus topics
+    setTopics([
+      "Hearts of Algebra",
+      "Problem Solving and Data Analysis",
+      "Geometry",
+      "Trigonometry",
+    ]);
+  }, []);
+
+  return (
+    <Stack gap={8}>
+      <Stack direction="row" gap={6} align="center">
+        <Avatar size={"lg"} src={"https://bit.ly/dan-abramov"} />
+
+        <Stack gap={0}>
+          <Text fontSize="2xl" fontWeight="bold" textTransform="capitalize">
+            {displayName}
+          </Text>
+
+          <Text>{email}</Text>
+        </Stack>
+      </Stack>
+
+      <Stack gap={3}>
+        <Stack direction="row" gap={4}>
+          <Text fontWeight="bold" fontSize="lg">
+            Focus topics:
+          </Text>
+
+          <Button variant="link" colorScheme="blue">
+            <Box marginRight="1">
+              <FaPencil />
+            </Box>
+            Edit
+          </Button>
+        </Stack>
+
+        <Stack direction="row" gap={4} wrap="wrap">
+          {topics.map((topic) => (
+            <Tag
+              key={topic}
+              size="lg"
+              variant="solid"
+              bgColor="#e2ab93"
+              color="#565656"
+              fontWeight="bold"
+              padding="0.5rem 1rem"
+              whiteSpace="nowrap"
+            >
+              {topic}
+            </Tag>
+          ))}
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+};

--- a/frontend/src/pages/settings/components/MostPracticedTopics.tsx
+++ b/frontend/src/pages/settings/components/MostPracticedTopics.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { Box, Grid, GridItem, Heading, Stack, Tag, VStack } from "@chakra-ui/react";
+import { Box, Heading, SimpleGrid, Stack, Tag } from "@chakra-ui/react";
 
 import { PieChart } from "../../../components/PieChart";
 
@@ -42,10 +42,10 @@ export const MostPracticedTopics = () => {
     <Stack gap={10}>
       <Heading size="lg">Most Practiced Topics This Week:</Heading>
 
-      <Grid templateColumns="repeat(3, 1fr)" gap={12}>
+      <SimpleGrid columns={{ lg: 3 }} gap={12}>
         {topicStats.map(({ name, totalCorrect, totalIncorrect }) => (
-          <GridItem key={name} as={VStack}>
-            <Box w="250px">
+          <Stack align="center">
+            <Box w="200px">
               <PieChart
                 slices={[
                   {
@@ -67,6 +67,7 @@ export const MostPracticedTopics = () => {
               color="#565656"
               fontSize="lg"
               fontWeight="bold"
+              h="full"
               justifyContent="center"
               marginTop="8"
               padding="3"
@@ -76,9 +77,9 @@ export const MostPracticedTopics = () => {
             >
               {name}
             </Tag>
-          </GridItem>
+          </Stack>
         ))}
-      </Grid>
+      </SimpleGrid>
     </Stack>
   );
 };

--- a/frontend/src/pages/settings/components/MostPracticedTopics.tsx
+++ b/frontend/src/pages/settings/components/MostPracticedTopics.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+
+import { Box, Grid, GridItem, Heading, Stack, Tag, VStack } from "@chakra-ui/react";
+
+import { PieChart } from "../../../components/PieChart";
+
+type TopicStats = {
+  name: string;
+  totalCorrect: number;
+  totalIncorrect: number;
+  totalQuestions: number;
+};
+
+export const MostPracticedTopics = () => {
+  const [topicStats, setTopicStats] = useState<TopicStats[]>([]);
+
+  useEffect(() => {
+    // TODO: Call API to get user's most practiced topics
+    setTopicStats([
+      {
+        name: "Problem Solving and Data Analysis",
+        totalIncorrect: 0.24,
+        totalCorrect: 0.76,
+        totalQuestions: 120,
+      },
+      {
+        name: "Trigonometry",
+        totalIncorrect: 0.5,
+        totalCorrect: 0.5,
+        totalQuestions: 100,
+      },
+      {
+        name: "Geometry",
+        totalIncorrect: 0.63,
+        totalCorrect: 0.37,
+        totalQuestions: 90,
+      },
+    ]);
+  }, []);
+
+  return (
+    <Stack gap={10}>
+      <Heading size="lg">Most Practiced Topics This Week:</Heading>
+
+      <Grid templateColumns="repeat(3, 1fr)" gap={12}>
+        {topicStats.map(({ name, totalCorrect, totalIncorrect }) => (
+          <GridItem key={name} as={VStack}>
+            <Box w="250px">
+              <PieChart
+                slices={[
+                  {
+                    label: "Correct",
+                    percentage: totalCorrect,
+                    color: "#e2ab93",
+                  },
+                  {
+                    label: "Incorrect",
+                    percentage: totalIncorrect,
+                    color: "#eccbbe",
+                  },
+                ]}
+              />
+            </Box>
+
+            <Tag
+              bgColor="#eccbbe"
+              color="#565656"
+              fontSize="lg"
+              fontWeight="bold"
+              justifyContent="center"
+              marginTop="8"
+              padding="3"
+              textAlign="center"
+              variant="solid"
+              w="full"
+            >
+              {name}
+            </Tag>
+          </GridItem>
+        ))}
+      </Grid>
+    </Stack>
+  );
+};

--- a/frontend/src/pages/settings/components/Preferences.tsx
+++ b/frontend/src/pages/settings/components/Preferences.tsx
@@ -1,0 +1,3 @@
+export const Preferences = () => {
+  return <></>;
+};

--- a/frontend/src/pages/settings/components/Preferences.tsx
+++ b/frontend/src/pages/settings/components/Preferences.tsx
@@ -6,7 +6,7 @@ export const Preferences = () => {
   const { preferences, updatePreferences } = usePreferences();
 
   return (
-    <Stack gap={6}>
+    <Stack gap={6} overflow="hidden">
       <Heading fontSize="3xl">Preferences:</Heading>
 
       <Switch

--- a/frontend/src/pages/settings/components/Preferences.tsx
+++ b/frontend/src/pages/settings/components/Preferences.tsx
@@ -1,3 +1,31 @@
+import { Heading, Stack, Switch } from "@chakra-ui/react";
+
+import { usePreferences } from "../hooks/use-preferences";
+
 export const Preferences = () => {
-  return <></>;
+  const { preferences, updatePreferences } = usePreferences();
+
+  return (
+    <Stack gap={6}>
+      <Heading fontSize="3xl">Preferences:</Heading>
+
+      <Switch
+        alignItems="center"
+        display="flex"
+        isChecked={preferences.timerRed}
+        onChange={() => updatePreferences({ timerRed: !preferences.timerRed })}
+      >
+        Timer turns red after 2 minute passes
+      </Switch>
+
+      <Switch
+        alignItems="center"
+        display="flex"
+        isChecked={preferences.showCorrectAnswer}
+        onChange={() => updatePreferences({ showCorrectAnswer: !preferences.showCorrectAnswer })}
+      >
+        Show correct answer before proceeding to next question
+      </Switch>
+    </Stack>
+  );
 };

--- a/frontend/src/pages/settings/hooks/use-preferences.ts
+++ b/frontend/src/pages/settings/hooks/use-preferences.ts
@@ -1,0 +1,25 @@
+import { useLocalStorage } from "@uidotdev/usehooks";
+
+export type Preferences = {
+  showCorrectAnswer?: boolean;
+  timerRed?: boolean;
+};
+
+export const usePreferences = () => {
+  const [preferences, setPreferences] = useLocalStorage<Preferences>("preferences", {
+    showCorrectAnswer: true,
+    timerRed: true,
+  });
+
+  const updatePreferences = (newPreferences: Partial<Preferences>) => {
+    setPreferences((currentPreferences) => ({
+      ...currentPreferences,
+      ...newPreferences,
+    }));
+  };
+
+  return {
+    preferences,
+    updatePreferences,
+  };
+};

--- a/frontend/src/pages/settings/index.ts
+++ b/frontend/src/pages/settings/index.ts
@@ -1,1 +1,3 @@
+export * from "./hooks/use-preferences";
+
 export * from "./routes/Settings";

--- a/frontend/src/pages/settings/index.ts
+++ b/frontend/src/pages/settings/index.ts
@@ -1,0 +1,1 @@
+export * from "./routes/Settings";

--- a/frontend/src/pages/settings/layouts/DefaultLayout.tsx
+++ b/frontend/src/pages/settings/layouts/DefaultLayout.tsx
@@ -1,0 +1,15 @@
+import { PropsWithChildren } from "react";
+
+import Navbar from "../../../components/Navbar";
+
+export const DefaultLayout = ({ children }: PropsWithChildren) => {
+  return (
+    <>
+      <header>
+        <Navbar />
+      </header>
+
+      <main>{children}</main>
+    </>
+  );
+};

--- a/frontend/src/pages/settings/layouts/DefaultLayout.tsx
+++ b/frontend/src/pages/settings/layouts/DefaultLayout.tsx
@@ -1,15 +1,21 @@
 import { PropsWithChildren } from "react";
 
+import { Box, BoxProps } from "@chakra-ui/react";
+
 import Navbar from "../../../components/Navbar";
 
-export const DefaultLayout = ({ children }: PropsWithChildren) => {
+type DefaultLayoutProps = BoxProps & PropsWithChildren;
+
+export const DefaultLayout = ({ children, ...props }: DefaultLayoutProps) => {
   return (
     <>
       <header>
         <Navbar />
       </header>
 
-      <main>{children}</main>
+      <main>
+        <Box {...props}>{children}</Box>
+      </main>
     </>
   );
 };

--- a/frontend/src/pages/settings/routes/Settings.tsx
+++ b/frontend/src/pages/settings/routes/Settings.tsx
@@ -1,12 +1,13 @@
-import { Box, Grid, GridItem } from "@chakra-ui/react";
+import { Box, Grid, GridItem, Stack } from "@chakra-ui/react";
 
 import { ExamDate } from "../components/ExamDate";
 import { FocusTopics } from "../components/FocusTopics";
+import { MostPracticedTopics } from "../components/MostPracticedTopics";
 
 export const Settings = () => {
   return (
-    <Box backgroundColor="gray">
-      <Grid templateColumns="repeat(2, 1fr)" gap={6} padding={6}>
+    <Stack backgroundColor="gray" gap={6} padding={6}>
+      <Grid templateColumns="repeat(2, 1fr)" gap={6}>
         <GridItem backgroundColor="white" borderRadius="lg" padding={12}>
           <FocusTopics />
         </GridItem>
@@ -15,6 +16,10 @@ export const Settings = () => {
           <ExamDate />
         </GridItem>
       </Grid>
-    </Box>
+
+      <Box backgroundColor="white" borderRadius="lg" padding={12}>
+        <MostPracticedTopics />
+      </Box>
+    </Stack>
   );
 };

--- a/frontend/src/pages/settings/routes/Settings.tsx
+++ b/frontend/src/pages/settings/routes/Settings.tsx
@@ -1,0 +1,15 @@
+import { Box, Grid, GridItem } from "@chakra-ui/react";
+
+import { FocusTopics } from "../components/FocusTopics";
+
+export const Settings = () => {
+  return (
+    <Box backgroundColor="gray">
+      <Grid templateColumns="repeat(2, 1fr)" gap={6} padding={6}>
+        <GridItem backgroundColor="white" borderRadius="lg" padding={12}>
+          <FocusTopics />
+        </GridItem>
+      </Grid>
+    </Box>
+  );
+};

--- a/frontend/src/pages/settings/routes/Settings.tsx
+++ b/frontend/src/pages/settings/routes/Settings.tsx
@@ -3,6 +3,7 @@ import { Box, Grid, GridItem, Stack } from "@chakra-ui/react";
 import { ExamDate } from "../components/ExamDate";
 import { FocusTopics } from "../components/FocusTopics";
 import { MostPracticedTopics } from "../components/MostPracticedTopics";
+import { Preferences } from "../components/Preferences";
 
 export const Settings = () => {
   return (
@@ -19,6 +20,10 @@ export const Settings = () => {
 
       <Box backgroundColor="white" borderRadius="lg" padding={12}>
         <MostPracticedTopics />
+      </Box>
+
+      <Box backgroundColor="white" borderRadius="lg" padding={12}>
+        <Preferences />
       </Box>
     </Stack>
   );

--- a/frontend/src/pages/settings/routes/Settings.tsx
+++ b/frontend/src/pages/settings/routes/Settings.tsx
@@ -9,8 +9,8 @@ import { DefaultLayout } from "../layouts/DefaultLayout";
 
 export const Settings = () => {
   return (
-    <DefaultLayout>
-      <Stack backgroundColor="gray.100" gap={6} padding={{ base: 4, md: 12 }}>
+    <DefaultLayout justifyContent="center" display="flex" backgroundColor="gray.100">
+      <Stack gap={6} maxW="max-content" padding={{ base: 4, md: 12 }}>
         <SimpleGrid columns={{ md: 2 }} gap={6}>
           <Box backgroundColor="white" borderRadius="lg" padding={{ base: 8, md: 12 }}>
             <FocusTopics />

--- a/frontend/src/pages/settings/routes/Settings.tsx
+++ b/frontend/src/pages/settings/routes/Settings.tsx
@@ -1,5 +1,6 @@
 import { Box, Grid, GridItem } from "@chakra-ui/react";
 
+import { ExamDate } from "../components/ExamDate";
 import { FocusTopics } from "../components/FocusTopics";
 
 export const Settings = () => {
@@ -8,6 +9,10 @@ export const Settings = () => {
       <Grid templateColumns="repeat(2, 1fr)" gap={6} padding={6}>
         <GridItem backgroundColor="white" borderRadius="lg" padding={12}>
           <FocusTopics />
+        </GridItem>
+
+        <GridItem backgroundColor="white" borderRadius="lg" padding={12}>
+          <ExamDate />
         </GridItem>
       </Grid>
     </Box>

--- a/frontend/src/pages/settings/routes/Settings.tsx
+++ b/frontend/src/pages/settings/routes/Settings.tsx
@@ -1,30 +1,36 @@
-import { Box, Grid, GridItem, Stack } from "@chakra-ui/react";
+import { Box, SimpleGrid, Stack } from "@chakra-ui/react";
 
 import { ExamDate } from "../components/ExamDate";
 import { FocusTopics } from "../components/FocusTopics";
 import { MostPracticedTopics } from "../components/MostPracticedTopics";
 import { Preferences } from "../components/Preferences";
 
+import { DefaultLayout } from "../layouts/DefaultLayout";
+
 export const Settings = () => {
   return (
-    <Stack backgroundColor="gray" gap={6} padding={6}>
-      <Grid templateColumns="repeat(2, 1fr)" gap={6}>
-        <GridItem backgroundColor="white" borderRadius="lg" padding={12}>
-          <FocusTopics />
-        </GridItem>
+    <DefaultLayout>
+      <Stack backgroundColor="gray.100" gap={6} padding={{ base: 4, md: 12 }}>
+        <SimpleGrid columns={{ md: 2 }} gap={6}>
+          <Box backgroundColor="white" borderRadius="lg" padding={{ base: 8, md: 12 }}>
+            <FocusTopics />
+          </Box>
 
-        <GridItem backgroundColor="white" borderRadius="lg" padding={12}>
-          <ExamDate />
-        </GridItem>
-      </Grid>
+          <Box backgroundColor="white" borderRadius="lg" padding={{ base: 8, md: 12 }}>
+            <ExamDate />
+          </Box>
+        </SimpleGrid>
 
-      <Box backgroundColor="white" borderRadius="lg" padding={12}>
-        <MostPracticedTopics />
-      </Box>
+        <SimpleGrid columns={1} gap={6}>
+          <Box backgroundColor="white" borderRadius="lg" padding={{ base: 8, md: 12 }}>
+            <MostPracticedTopics />
+          </Box>
 
-      <Box backgroundColor="white" borderRadius="lg" padding={12}>
-        <Preferences />
-      </Box>
-    </Stack>
+          <Box backgroundColor="white" borderRadius="lg" padding={{ base: 8, md: 12 }}>
+            <Preferences />
+          </Box>
+        </SimpleGrid>
+      </Stack>
+    </DefaultLayout>
   );
 };

--- a/frontend/src/router/Router.tsx
+++ b/frontend/src/router/Router.tsx
@@ -5,6 +5,7 @@ import { RequireNoAuth } from "./guards/RequireNoAuth";
 
 import { ForgotPassword, Login, Register } from "../pages/auth";
 import HomePage from "../pages/Home";
+import { Settings } from "../pages/settings";
 
 export const router = createBrowserRouter([
   {
@@ -32,8 +33,12 @@ export const router = createBrowserRouter([
         children: [
           {
             path: "",
-            element: <HomePage />
-          }
+            element: <HomePage />,
+          },
+          {
+            path: "settings",
+            element: <Settings />,
+          },
         ],
       },
     ],


### PR DESCRIPTION
This PR adds the settings page. We still need to implement API calls for things like focused topics, exam dates, and most practiced topics, but I put placeholders for now.

You can import `usePreferences()` hook from `./pages/settings` to get the preferences like if the timer should turn red if 2 mins is remaining, etc... so it can be implemented in the answer page accordingly.